### PR TITLE
fix(devtools-action-filter): return new action object

### DIFF
--- a/react/Store.js
+++ b/react/Store.js
@@ -6,7 +6,9 @@ const enhancer = compose(
         ? window.devToolsExtension({
             actionsFilter: (action) => {
                 if (typeof action.type === 'symbol') {
-                    action.type = action.type.toString();
+                    const actionCopy = {...action}; // Don't change the original action
+                    actionCopy.type = action.type.toString(); // DevTools doesn't work with Symbols
+                    return actionCopy;
                 }
                 return action;
             }


### PR DESCRIPTION
Mutating the original action causes problems in reducers when doing request to the backend. After response, reducers does not match the action type because it was converted to string from Symbol.
