### PR TITLE
fix: ABT-1682: convert immutable action.params to plain js

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "history": "3.2.1",
     "inert": "4.0.4",
+    "immutable": "3.8.1",
     "lodash.assign": "4.2.0",
     "os-browserify": "0.2.1",
     "react": "15.4.1",


### PR DESCRIPTION
Some action creators in redux pass immutable as action.params.
This fixes the issue while retaining the immutability of action.params.