### PR TITLE
fix: consistently return promise when dispatching action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-front",
-  "version": "7.2.0",
+  "version": "7.2.1-promisifyAllActions.0",
   "description": "Frontend module",
   "main": "index.js",
   "scripts": {

--- a/react/middleware.js
+++ b/react/middleware.js
@@ -28,7 +28,7 @@ export default (utBus) => {
 
             if (action.abort) {
                 action.methodRequestState = 'finished';
-                return next(action);
+                return Promise.resolve(next(action));
             }
             var methodParams = cloneParams(action.params);
             if (corsCookie) {
@@ -53,7 +53,7 @@ export default (utBus) => {
                     return next(action);
                 });
         }
-        return next(action);
+        return Promise.resolve(next(action));
     };
 
     const utBuslogger = (store) => (next) => (action) => {


### PR DESCRIPTION
Fixes an inconsistency where the `rpc middleware` returns promises *only* for actions that hit the backend.