### PR TITLE
fix: UTP-1489: disable redux dev tools extension when not in debug mode

### DIFF
--- a/react/Store.js
+++ b/react/Store.js
@@ -13,8 +13,8 @@ const resetStore = (reducer, resetAction) => {
     };
 };
 
-const enhancer = compose(
-    window && window.devToolsExtension
+const enhancer = utBusConfig => compose(
+    utBusConfig.debug && window && window.devToolsExtension
         ? window.devToolsExtension({
             serialize: true,
             actionSanitizer: (action) => {
@@ -29,11 +29,11 @@ const enhancer = compose(
         : f => f
 );
 
-export function Store(reducers, resetAction, middlewares, environment) {
+export function Store(reducers, resetAction, middlewares, environment, utBusConfig = {}) {
     const mixedReducers = combineReducers({
         routing: routerReducer,
         ...reducers
     });
     const store = applyMiddleware(...middlewares)(createStore);
-    return store(resetStore(mixedReducers, resetAction), {}, enhancer);
+    return store(resetStore(mixedReducers, resetAction), {}, enhancer(utBusConfig));
 };

--- a/react/index.js
+++ b/react/index.js
@@ -15,7 +15,8 @@ export class UtFront extends React.Component {
             this.props.reducers,
             this.props.resetAction,
             UtFrontMiddleware(this.props.utBus).concat(this.props.middlewares),
-            this.props.environment
+            this.props.environment,
+            this.props.utBus.config
         );
         this.history = syncHistoryWithStore(useRouterHistory(createHashHistory)(), this.store);
     }


### PR DESCRIPTION
This disables the redux dev tools when in debug mode.
There is one problem - implementations need to have different frontend configs for different environments.